### PR TITLE
Adiciona fundo 3D com Three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm start
 ```
 
 A aplicação será aberta com `live-server` em `src/index.html`.
+O fundo agora utiliza a biblioteca [Three.js](https://threejs.org/)
+para criar um campo de estrelas.
 
 ## Construir para produção
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import Game from './game.js';
+import StarField from './starfield.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -10,12 +11,15 @@ function resize() {
 window.addEventListener('resize', resize);
 resize();
 
+const starfield = new StarField();
 const game = new Game(canvas, ctx);
 let lastTime = 0;
 
 function loop(timestamp) {
   const delta = timestamp - lastTime;
   lastTime = timestamp;
+  starfield.update(delta);
+  starfield.render();
   game.update(delta);
   game.draw();
   requestAnimationFrame(loop);

--- a/src/starfield.js
+++ b/src/starfield.js
@@ -1,0 +1,49 @@
+import * as THREE from 'https://unpkg.com/three@0.157.0/build/three.module.js';
+
+export default class StarField {
+  constructor() {
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(
+      60,
+      window.innerWidth / window.innerHeight,
+      1,
+      1000
+    );
+    this.camera.position.z = 1;
+
+    this.renderer = new THREE.WebGLRenderer({ alpha: true });
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.renderer.domElement.style.position = 'absolute';
+    this.renderer.domElement.style.top = 0;
+    this.renderer.domElement.style.left = 0;
+    this.renderer.domElement.style.zIndex = 0;
+    document.body.appendChild(this.renderer.domElement);
+
+    const starCount = 500;
+    const positions = new Float32Array(starCount * 3);
+    for (let i = 0; i < starCount * 3; i++) {
+      positions[i] = (Math.random() - 0.5) * 500;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const material = new THREE.PointsMaterial({ color: 0xffffff, size: 1 });
+    this.stars = new THREE.Points(geometry, material);
+    this.scene.add(this.stars);
+
+    window.addEventListener('resize', () => this.onResize());
+  }
+
+  onResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  update(delta) {
+    this.stars.rotation.y += delta * 0.00005;
+  }
+
+  render() {
+    this.renderer.render(this.scene, this.camera);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,6 +19,8 @@ body {
 #gameCanvas {
   width: 100%;
   height: 100%;
+  position: relative;
+  z-index: 1;
 }
 
 /* Canvas will scale to fill viewport while maintaining aspect */


### PR DESCRIPTION
## Summary
- adiciona `StarField` usando Three.js para criar estrelas animadas
- integra o fundo ao loop principal
- ajusta CSS para garantir canvas sobreposto
- documenta uso de Three.js no README

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: live-server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7aa25db8832481afce9fc4101252